### PR TITLE
Adding missing define and missing braces

### DIFF
--- a/gpio/gpio.c
+++ b/gpio/gpio.c
@@ -213,9 +213,9 @@ static void doLoad (int argc, char *argv [])
   else
     _doLoadUsage (argv) ;
 
-  if (piModel == PI_MODEL_PINE64 {
+  if (piModel == PI_MODEL_PINE64) {
     if (strcasecmp (argv [2], "i2c") == 0)  {
-      if (piModel == PI_MODEL_PINE64  {
+      if (piModel == PI_MODEL_PINE64)  {
         module1 = "aml-i2c";
         file1 = "/dev/i2c-1";
         file2 = "/dev/i2c-2";

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -79,6 +79,7 @@
 #define	PI_MODEL_ODROIDC  6
 #define PI_MODEL_ODROIDXU_34    7
 #define	PI_MODEL_ODROIDC2	8
+#define PI_MODEL_PINE64         9
 
 #define	PI_VERSION_UNKNOWN	0
 #define	PI_VERSION_1        1


### PR DESCRIPTION
When trying to compile this code on a pine64 running debian it failed due to missing closing brackets and a missing define.

```
GPIO Utility
[Compile] gpio.c
gpio.c: In function ‘doLoad’:
gpio.c:216:18: error: ‘PI_MODEL_PINE64’ undeclared (first use in this function)
   if (piModel == PI_MODEL_PINE64) {
                  ^
gpio.c:216:18: note: each undeclared identifier is reported only once for each function it appears in
gpio.c:218:39: error: expected ‘)’ before ‘{’ token
       if (piModel == PI_MODEL_PINE64  {
                                       ^
gpio.c:236:5: error: expected expression before ‘}’ token
```
